### PR TITLE
Require parens in arrow function arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -756,7 +756,7 @@ const baseRules = {
 	'arrow-body-style': ['error', 'as-needed'],
 
 	// Error because consistency matters
-	'arrow-parens': ['error', 'as-needed', {requireForBlockBody: false}],
+	'arrow-parens': ['error', 'always'],
 
 	// Error becuase readability counts
 	'arrow-spacing': ['error', {before: true, after: true}],


### PR DESCRIPTION
- It's an inconsistency to allow `x => x` but require `(x, y) => x + y`
- It's easier to read a complex function call block that may have
  multiple arrow functions if args are in parens
- Functions in math are typically defined with parameters in parens
- `const f = {a} => a` is a syntax error and requires parens